### PR TITLE
[Feat/#5] 뉴스 페이지 서버통신 

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,6 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="Android Studio java home" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,9 +4,11 @@ plugins {
     id 'kotlin-kapt'
     id 'kotlin-parcelize'
     id 'com.google.dagger.hilt.android'
-    id 'com.google.gms.google-services'
     id 'org.jetbrains.kotlin.plugin.serialization' version '1.8.20'
 }
+
+def localProperties = new Properties()
+localProperties.load(new FileInputStream(rootProject.file("local.properties")))
 
 android {
     namespace 'com.example.socialproblemandroid'
@@ -20,6 +22,8 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "API_KEY", localProperties['API_KEY'])
+        buildConfigField("String","NEWS_BASE_URL",localProperties['NEWS_BASE_URL'])
     }
 
     buildTypes {
@@ -29,11 +33,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     buildFeatures {
@@ -104,4 +108,10 @@ dependencies {
 
     //viewpager2
     implementation "androidx.viewpager2:viewpager2:1.0.0"
+
+    //xml parser
+    implementation 'com.tickaroo.tikxml:annotation:0.8.13'
+    implementation 'com.tickaroo.tikxml:core:0.8.13'
+    implementation 'com.tickaroo.tikxml:retrofit-converter:0.8.13'
+    kapt 'com.tickaroo.tikxml:processor:0.8.13'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".presentation.news.NewsActivity"
+            android:exported="false"
+            android:screenOrientation="portrait"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/socialproblemandroid/App.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/App.kt
@@ -2,7 +2,9 @@ package com.example.socialproblemandroid
 
 import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
+import dagger.hilt.android.HiltAndroidApp
 
+@HiltAndroidApp
 class App : Application() {
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/com/example/socialproblemandroid/data/datasource/NewsDataSource.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/data/datasource/NewsDataSource.kt
@@ -1,0 +1,9 @@
+package com.example.socialproblemandroid.data.datasource
+
+import com.example.socialproblemandroid.data.model.remote.response.NewsResponse
+import com.example.socialproblemandroid.data.service.NewsService
+import javax.inject.Inject
+
+interface NewsDataSource {
+    suspend fun getNewsInfo() :NewsResponse
+}

--- a/app/src/main/java/com/example/socialproblemandroid/data/datasourceimpl/NewsDataSourceImpl.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/data/datasourceimpl/NewsDataSourceImpl.kt
@@ -1,0 +1,12 @@
+package com.example.socialproblemandroid.data.datasourceimpl
+
+import com.example.socialproblemandroid.data.datasource.NewsDataSource
+import com.example.socialproblemandroid.data.model.remote.response.NewsResponse
+import com.example.socialproblemandroid.data.service.NewsService
+import javax.inject.Inject
+
+class NewsDataSourceImpl @Inject constructor(
+    private val newsService: NewsService
+) : NewsDataSource {
+    override suspend fun getNewsInfo() = newsService.getNewsInfo()
+}

--- a/app/src/main/java/com/example/socialproblemandroid/data/model/remote/request/RequestNewsDto.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/data/model/remote/request/RequestNewsDto.kt
@@ -1,0 +1,4 @@
+package com.example.socialproblemandroid.data.model.remote.request
+
+class RequestNewsDto {
+}

--- a/app/src/main/java/com/example/socialproblemandroid/data/model/remote/response/ResponseNewsDto.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/data/model/remote/response/ResponseNewsDto.kt
@@ -1,0 +1,86 @@
+package com.example.socialproblemandroid.data.model.remote.response
+
+import com.tickaroo.tikxml.annotation.Element
+import com.tickaroo.tikxml.annotation.PropertyElement
+import com.tickaroo.tikxml.annotation.Xml
+
+@Xml(name = "response")
+data class NewsResponse(
+    @PropertyElement (name="script")
+    val script: String?,
+    @Element (name="header")
+    val header: NewsHeader,
+    @Element (name="body")
+    val body: NewsBody
+)
+
+@Xml(name = "header")
+data class NewsHeader(
+    @PropertyElement (name="resultCode")
+    val resultCode: String,
+    @PropertyElement (name="resultMsg")
+    val resultMsg: String
+)
+
+@Xml(name = "body")
+data class NewsBody(
+    @Element(name="NewsItem")
+    val newsItems: List<NewsItem>
+)
+
+@Xml(name = "NewsItem")
+data class NewsItem(
+    @PropertyElement(name="NewsItemId")
+    val newsItemId: String?,
+
+    @PropertyElement(name="ContentsStatus")
+    val contentsStatus: String?,
+
+    @PropertyElement(name="ModifyId")
+    val modifyId: String?,
+
+    @PropertyElement(name = "ModifyDate")
+    val modifyDate: String?,
+
+    @PropertyElement(name = "ApproveDate")
+    val approveDate: String?,
+
+    @PropertyElement(name = "ApproverName")
+    val approverName: String?,
+
+    @PropertyElement(name = "EmbargoDate")
+    val embargoDate: String?,
+
+    @PropertyElement(name = "GroupingCode")
+    val groupingCode: String?,
+
+    @PropertyElement(name = "Title")
+    val title: String?,
+
+    @PropertyElement(name = "SubTitle1")
+    val subTitle1: String?,
+
+    @PropertyElement(name = "SubTitle2")
+    val subTitle2: String?,
+
+    @PropertyElement(name = "SubTitle3")
+    val subTitle3: String?,
+
+    @PropertyElement(name = "ContentsType")
+    val contentsType: String?,
+
+    @PropertyElement(name = "DataContents")
+    val dataContents: String?,
+
+    @PropertyElement(name = "MinisterCode")
+    val ministerCode: String?,
+
+    @PropertyElement(name = "OriginalUrl")
+    val originalUrl: String?,
+
+    @PropertyElement(name = "ThumbnailUrl")
+    val thumbnailUrl: String?,
+
+    @PropertyElement(name = "OriginalimgUrl")
+    val originalImgUrl: String?
+)

--- a/app/src/main/java/com/example/socialproblemandroid/data/repository/NewsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/data/repository/NewsRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package com.example.socialproblemandroid.data.repository
+
+import android.util.Log
+import com.example.socialproblemandroid.data.datasource.NewsDataSource
+import com.example.socialproblemandroid.data.model.remote.response.NewsResponse
+import com.example.socialproblemandroid.domain.repository.NewsRepository
+import javax.inject.Inject
+
+class NewsRepositoryImpl @Inject constructor(private val newsDataSource: NewsDataSource) :
+    NewsRepository {
+    override suspend fun getNewsInfo(): Result<NewsResponse> =
+        runCatching {
+            newsDataSource.getNewsInfo()
+        }.onSuccess {
+            Log.e("hyeoon", "news 데이터 통신 성공")
+            Log.e("hyeon",it.toString())
+        }.onFailure {
+            Log.e("hyeoon",it.message.toString())
+            Log.e("hyeoon", "news 데이터 통신 실패")
+        }
+}

--- a/app/src/main/java/com/example/socialproblemandroid/data/service/DocumentsService.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/data/service/DocumentsService.kt
@@ -1,0 +1,4 @@
+package com.example.socialproblemandroid.data.service
+
+interface DocumentsService {
+}

--- a/app/src/main/java/com/example/socialproblemandroid/data/service/NewsService.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/data/service/NewsService.kt
@@ -1,0 +1,15 @@
+package com.example.socialproblemandroid.data.service
+
+import com.example.socialproblemandroid.BuildConfig
+import com.example.socialproblemandroid.data.model.remote.response.NewsResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface NewsService {
+    @GET("policyNewsList")
+    suspend fun getNewsInfo(
+        @Query("serviceKey") apiKey: String = BuildConfig.API_KEY,
+        @Query("startDate") startDate: String ="20240223",
+        @Query("endDate") endDate: String ="20240223"
+    ): NewsResponse
+}

--- a/app/src/main/java/com/example/socialproblemandroid/di/DataSourceModule.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/di/DataSourceModule.kt
@@ -1,0 +1,17 @@
+package com.example.socialproblemandroid.di
+
+import com.example.socialproblemandroid.data.datasource.NewsDataSource
+import com.example.socialproblemandroid.data.datasourceimpl.NewsDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DataSourceModule {
+    @Binds
+    @Singleton
+    abstract fun bindsNewsDataSource(newsDataSourceImpl: NewsDataSourceImpl): NewsDataSource
+}

--- a/app/src/main/java/com/example/socialproblemandroid/di/NetworkModule.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/di/NetworkModule.kt
@@ -1,0 +1,63 @@
+package com.example.socialproblemandroid.di
+
+import com.example.socialproblemandroid.BuildConfig
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import com.tickaroo.tikxml.retrofit.TikXmlConverterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import retrofit2.Converter
+import retrofit2.Retrofit
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+    @Provides
+    @Singleton
+    @Named("jsonRetrofit")
+    fun provideITdaRetrofit(client: OkHttpClient, @Named("jsonConverter")jsonConverter: Converter.Factory): Retrofit =
+        Retrofit.Builder()
+            .baseUrl("") // 잇다 BASE_URL
+            .client(client)
+            .addConverterFactory(jsonConverter)
+            .build()
+    // JSON 데이터를 통신하기 위한 Retrofit 인스턴스를 제공하는 메서드
+
+    @Provides
+    @Singleton
+    @Named("jsonConverter")
+    fun provideJsonConverterFactory(): Converter.Factory {
+        return Json.asConverterFactory("application/json".toMediaType())
+    }
+
+    @Provides
+    @Singleton
+    @Named("xmlConverter")
+    fun provideXmlConverterFactory(): Converter.Factory {
+        return TikXmlConverterFactory.create()
+    }
+
+    @Provides
+    @Singleton
+    @Named("xmlRetrofit")
+    fun provideNewsRetrofit(client: OkHttpClient, @Named("xmlConverter")xmlConverter: Converter.Factory): Retrofit =
+        Retrofit.Builder()
+            .baseUrl(BuildConfig.NEWS_BASE_URL) // XML 데이터 BASE_URL
+            .client(client)
+            .addConverterFactory(xmlConverter)
+            .build()
+    // XML 데이터를 통신하기 위한 Retrofit 인스턴스를 제공 메서드
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(): OkHttpClient = OkHttpClient.Builder()
+        .build()
+
+}

--- a/app/src/main/java/com/example/socialproblemandroid/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/di/RepositoryModule.kt
@@ -1,0 +1,17 @@
+package com.example.socialproblemandroid.di
+
+import com.example.socialproblemandroid.data.repository.NewsRepositoryImpl
+import com.example.socialproblemandroid.domain.repository.NewsRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+    @Binds
+    @Singleton
+    abstract fun bindNewsRepository(newsRepositoryImpl: NewsRepositoryImpl): NewsRepository
+}

--- a/app/src/main/java/com/example/socialproblemandroid/di/ServiceModule.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/di/ServiceModule.kt
@@ -1,0 +1,29 @@
+package com.example.socialproblemandroid.di
+
+import com.example.socialproblemandroid.data.service.DocumentsService
+import com.example.socialproblemandroid.data.service.NewsService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ServiceModule {
+
+    // XML 뉴스데이터 통신 service
+    @Provides
+    @Singleton
+    fun provideNewsService(@Named("xmlRetrofit")retrofit: Retrofit): NewsService =
+        retrofit.create(NewsService::class.java)
+
+
+    // 문서 번역 통신 service
+    @Provides
+    @Singleton
+    fun provideDocumentsService(@Named("jsonRetrofit")retrofit:Retrofit) : DocumentsService =
+        retrofit.create(DocumentsService::class.java)
+}

--- a/app/src/main/java/com/example/socialproblemandroid/domain/repository/NewsRepository.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/domain/repository/NewsRepository.kt
@@ -1,0 +1,7 @@
+package com.example.socialproblemandroid.domain.repository
+
+import com.example.socialproblemandroid.data.model.remote.response.NewsResponse
+
+interface NewsRepository {
+    suspend fun getNewsInfo() : Result<NewsResponse>
+}

--- a/app/src/main/java/com/example/socialproblemandroid/presentation/ChatFragment.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/presentation/ChatFragment.kt
@@ -2,8 +2,10 @@ package com.example.socialproblemandroid.presentation
 
 import com.example.socialproblemandroid.R
 import com.example.socialproblemandroid.databinding.FragmentChatBinding
-import com.example.socialproblemandroid.util.BindingFragment
+import com.example.socialproblemandroid.util.base.BindingFragment
+import dagger.hilt.android.AndroidEntryPoint
 
-class ChatFragment : BindingFragment<FragmentChatBinding> (R.layout.fragment_chat) {
+@AndroidEntryPoint
+class ChatFragment : BindingFragment<FragmentChatBinding>(R.layout.fragment_chat) {
 
 }

--- a/app/src/main/java/com/example/socialproblemandroid/presentation/HomeFragment.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/presentation/HomeFragment.kt
@@ -1,9 +1,0 @@
-package com.example.socialproblemandroid.presentation
-
-import com.example.socialproblemandroid.R
-import com.example.socialproblemandroid.databinding.FragmentHomeBinding
-import com.example.socialproblemandroid.util.BindingFragment
-
-class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home){
-
-}

--- a/app/src/main/java/com/example/socialproblemandroid/presentation/MainActivity.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/presentation/MainActivity.kt
@@ -1,13 +1,15 @@
 package com.example.socialproblemandroid.presentation
 
 import android.content.Context
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import com.example.socialproblemandroid.R
 import com.example.socialproblemandroid.databinding.ActivityMainBinding
-import com.example.socialproblemandroid.util.BindingActivity
+import com.example.socialproblemandroid.presentation.home.HomeFragment
+import com.example.socialproblemandroid.util.base.BindingActivity
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main) {
 
     private lateinit var context : Context

--- a/app/src/main/java/com/example/socialproblemandroid/presentation/MyPageFragment.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/presentation/MyPageFragment.kt
@@ -2,7 +2,9 @@ package com.example.socialproblemandroid.presentation
 
 import com.example.socialproblemandroid.R
 import com.example.socialproblemandroid.databinding.FragmentMypageBinding
-import com.example.socialproblemandroid.util.BindingFragment
+import com.example.socialproblemandroid.util.base.BindingFragment
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MyPageFragment : BindingFragment<FragmentMypageBinding>(R.layout.fragment_mypage) {
 }

--- a/app/src/main/java/com/example/socialproblemandroid/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/presentation/home/HomeFragment.kt
@@ -1,0 +1,41 @@
+package com.example.socialproblemandroid.presentation.home
+
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import androidx.fragment.app.viewModels
+import com.example.socialproblemandroid.R
+import com.example.socialproblemandroid.databinding.FragmentHomeBinding
+import com.example.socialproblemandroid.presentation.home.news.NewsAdapter
+import com.example.socialproblemandroid.presentation.news.NewsActivity
+import com.example.socialproblemandroid.util.base.BindingFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home){
+    private val viewModel: HomeViewModel by viewModels()
+    private lateinit var newsAdapter: NewsAdapter
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        initAdapter()
+        observeNewsData()
+    }
+
+    private fun observeNewsData(){
+        viewModel.newsResponse.observe(viewLifecycleOwner) {
+            newsAdapter.submitList(it)
+        }
+    }
+
+    private fun initAdapter() {
+        newsAdapter = NewsAdapter {
+            Intent(Intent(requireContext(), NewsActivity::class.java)).apply {
+                startActivity(this)
+            }
+        }
+        binding.rvTodayNews.adapter = newsAdapter
+    }
+}

--- a/app/src/main/java/com/example/socialproblemandroid/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/presentation/home/HomeViewModel.kt
@@ -1,0 +1,36 @@
+package com.example.socialproblemandroid.presentation.home
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.socialproblemandroid.data.model.remote.response.NewsItem
+import com.example.socialproblemandroid.domain.repository.NewsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HomeViewModel @Inject constructor(private val newsRepository: NewsRepository) : ViewModel() {
+
+    init{
+        getNewsInfo()
+    }
+
+    private var _newsResponse = MutableLiveData<List<NewsItem>>()
+    val newsResponse: LiveData<List<NewsItem>> = _newsResponse
+
+    fun getNewsInfo() {
+        viewModelScope.launch {
+            newsRepository.getNewsInfo()
+                .onSuccess { newsResponse ->
+                    _newsResponse.value = newsResponse.body.newsItems
+                    Log.e("hyeon", "news get 성공 ")
+                    Log.e("hyeon",_newsResponse.value.toString())
+                }.onFailure {
+                    Log.e("hyeon", "news get 실패 ")
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/example/socialproblemandroid/presentation/home/news/NewsAdapter.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/presentation/home/news/NewsAdapter.kt
@@ -1,0 +1,63 @@
+package com.example.socialproblemandroid.presentation.home.news
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import coil.load
+import com.example.socialproblemandroid.data.model.remote.response.NewsItem
+import com.example.socialproblemandroid.data.model.remote.response.NewsResponse
+import com.example.socialproblemandroid.databinding.ItemTodayNewsBinding
+import com.example.socialproblemandroid.util.setOnSingleClickListener
+
+
+class NewsAdapter(private val itemClick: (NewsItem) -> (Unit)) : ListAdapter<NewsItem, NewsAdapter.NewsViewHolder>(diffUtil) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NewsViewHolder{
+        val binding =
+            ItemTodayNewsBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return NewsViewHolder(binding, itemClick)
+    }
+
+    override fun onBindViewHolder(holder: NewsViewHolder, position: Int) {
+        holder.onBind(currentList[position])
+    }
+
+    class NewsViewHolder(
+        private val binding: ItemTodayNewsBinding,
+        private val itemClick: (NewsItem) -> (Unit)
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun onBind(data: NewsItem) {
+            with(binding) {
+                tvNewsTopic.text = data.title
+                ivNewsTumbnail.load(data.originalImgUrl){
+                    crossfade(true)
+                }
+                tvNewsTag.text = "" //content에 contains로 tag 판단 (type 사용하기!)
+                root.setOnSingleClickListener {
+                    itemClick(data)
+                }
+            }
+        }
+    }
+
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<NewsItem>() {
+            override fun areItemsTheSame(
+                oldItem: NewsItem,
+                newItem: NewsItem
+            ): Boolean {
+                return oldItem.newsItemId == newItem.newsItemId
+            }
+
+            override fun areContentsTheSame(
+                oldItem: NewsItem,
+                newItem: NewsItem
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/socialproblemandroid/presentation/news/NewsActivity.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/presentation/news/NewsActivity.kt
@@ -1,0 +1,14 @@
+package com.example.socialproblemandroid.presentation.news
+
+import android.os.Bundle
+import com.example.socialproblemandroid.R
+import com.example.socialproblemandroid.databinding.ActivityNewsBinding
+import com.example.socialproblemandroid.util.base.BindingActivity
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class NewsActivity : BindingActivity<ActivityNewsBinding>(R.layout.activity_news) {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+}

--- a/app/src/main/java/com/example/socialproblemandroid/util/ViewExtension.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/util/ViewExtension.kt
@@ -1,0 +1,17 @@
+package com.example.socialproblemandroid.util
+
+import android.view.View
+
+inline fun View.setOnSingleClickListener(
+    delay: Long = 500L,
+    crossinline block: (View) -> Unit
+) {
+    var previousClickedTime = 0L
+    setOnClickListener { view ->
+        val clickedTime = System.currentTimeMillis()
+        if (clickedTime - previousClickedTime >= delay) {
+            block(view)
+            previousClickedTime = clickedTime
+        }
+    }
+}

--- a/app/src/main/java/com/example/socialproblemandroid/util/base/BindingActivity.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/util/base/BindingActivity.kt
@@ -1,4 +1,4 @@
-package com.example.socialproblemandroid.util
+package com.example.socialproblemandroid.util.base
 
 import android.os.Bundle
 import androidx.annotation.LayoutRes

--- a/app/src/main/java/com/example/socialproblemandroid/util/base/BindingFragment.kt
+++ b/app/src/main/java/com/example/socialproblemandroid/util/base/BindingFragment.kt
@@ -1,4 +1,4 @@
-package com.example.socialproblemandroid.util
+package com.example.socialproblemandroid.util.base
 
 import android.os.Bundle
 import android.view.LayoutInflater

--- a/app/src/main/res/drawable/ic_document.xml
+++ b/app/src/main/res/drawable/ic_document.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="18dp"
+    android:viewportWidth="18"
+    android:viewportHeight="18">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M6.5,10.5H11.5M6.5,12.5H13.5M6.5,14.5H9.5M16.5,15.5V8.5L11.5,3.5H6.5C5.97,3.5 5.461,3.711 5.086,4.086C4.711,4.461 4.5,4.97 4.5,5.5V15.5C4.5,16.03 4.711,16.539 5.086,16.914C5.461,17.289 5.97,17.5 6.5,17.5H14.5C15.03,17.5 15.539,17.289 15.914,16.914C16.289,16.539 16.5,16.03 16.5,15.5Z"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M11.5,3.5V6.5C11.5,7.03 11.711,7.539 12.086,7.914C12.461,8.289 12.97,8.5 13.5,8.5H16.5"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -30,7 +30,6 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:background="@color/white"
-                app:itemActiveIndicatorStyle="@null"
                 app:itemIconSize="24dp"
                 app:itemTextColor="@color/black"
                 app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/activity_news.xml
+++ b/app/src/main/res/layout/activity_news.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<layout>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <data>
+
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -48,6 +48,7 @@
                     tools:listitem="@layout/item_today_news"
                     android:orientation="vertical"
                     android:layout_marginHorizontal="16dp"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     app:layout_constraintTop_toBottomOf="@id/tv_sub_title"
                     tools:itemCount="3" />
 

--- a/app/src/main/res/layout/item_today_news.xml
+++ b/app/src/main/res/layout/item_today_news.xml
@@ -8,49 +8,43 @@
         android:id="@+id/iv_news_tumbnail"
         android:layout_width="match_parent"
         app:layout_constraintTop_toTopOf="parent"
-        android:layout_height="wrap_content"
-        app:layout_aspectRatio="100%"
+        android:layout_height="345dp"
+        android:scaleType="centerCrop"
         android:src="@drawable/iv_news"
         />
-    
+
+    <TextView
+        android:id="@+id/tv_news_topic"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="세금 관련 뉴스"
+        app:layout_constraintTop_toBottomOf="@id/iv_news_tumbnail"
+        android:layout_marginHorizontal="8dp"
+        android:layout_marginTop="12dp"
+        android:textStyle="bold"
+        android:textSize="21sp"/>
+
+
     <ImageView
         android:id="@+id/iv_topic_tumbnail"
         android:layout_width="28dp"
         android:layout_height="28dp"
         android:src="@drawable/img_money"
-        app:layout_constraintTop_toBottomOf="@id/iv_news_tumbnail"
-        app:layout_constraintEnd_toStartOf="@id/tv_news_topic"
-        app:layout_constraintBottom_toBottomOf="@id/tv_news_topic"
-        android:layout_marginTop="8dp"
-        android:layout_marginStart="4dp"
+        app:layout_constraintTop_toBottomOf="@id/tv_news_topic"
+        app:layout_constraintEnd_toStartOf="@id/tv_news_tag"
+        app:layout_constraintBottom_toBottomOf="@id/tv_news_tag"
+        android:layout_marginTop="4dp"
+        android:layout_marginStart="8dp"
         app:layout_constraintStart_toStartOf="parent"/>
 
     <TextView
-        android:id="@+id/tv_news_topic"
+        android:id="@+id/tv_news_tag"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="세금 관련 뉴스"
-        app:layout_constraintStart_toEndOf="@id/iv_topic_tumbnail"
-        app:layout_constraintTop_toBottomOf="@id/iv_news_tumbnail"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:textStyle="bold"
-        android:textSize="18sp"/>
-
-    <TextView
-        android:id="@+id/tv_news_tag"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintBottom_toBottomOf="parent"
         android:text="#세금 #회계 #환급 #정산"
-        app:layout_constraintTop_toBottomOf="@id/tv_news_topic"
-        android:layout_marginTop="2dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginStart="4dp"
+        app:layout_constraintStart_toEndOf="@id/iv_topic_tumbnail"
         android:textSize="12sp"
-        android:layout_marginBottom="8dp"/>
-
-
-
-
-
-
+        android:layout_marginBottom="15dp"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/menu_bottom.xml
+++ b/app/src/main/res/menu/menu_bottom.xml
@@ -5,6 +5,10 @@
         android:title="홈"
         android:icon="@drawable/ic_home" />
     <item
+        android:id="@+id/menu_document"
+        android:title="서류"
+        android:icon="@drawable/ic_document"/>
+    <item
         android:id="@+id/menu_chat"
         android:title="채팅"
         android:icon="@drawable/ic_chat"  />


### PR DESCRIPTION
## 🎀 Related Issues

#### close #5 

## 🐶 What Did You Do

- [x] 공공 API 서버 연결하기 (XML 파싱)
- [x] RV Adapter 생성 (DiffUtil 활용)
- [x] Item 클릭 시 뉴스 상세화면으로 이동
- [x] Htil 이용한 DI 적용
- [x] 클린 아키텍처로 패키지 분리 

## ✨ 새롭게 알게된 점 및 앞으로 할 일 
- Hilt 에서 여러개의 Base_url을 사용할 때 분리하는 방법을 배울 수 있었다. (@ Named 어노테이션 활용)
- json이 아닌 xml 데이터로 response가 올 때 이를 파싱하는 방법을 배울 수 있었다.
- Repository -> RepositoryImpl -> DataSource -> DataSourceImpl 로 분리하면서 의존성 주입을 위해 Repository Module 뿐만아니라 DataSourceModule도 필요함을 알게되었다.
- 서버 통신으로 받아오는 데이터의 로딩 관리 필요성을 느꼈다. 
